### PR TITLE
Fix proguard to keep RemoteMetadataProvider

### DIFF
--- a/proguard-android.txt
+++ b/proguard-android.txt
@@ -119,6 +119,8 @@
 ###################################
 -dontwarn android.media.IRemoteControlDisplay**
 -dontwarn android.media.AudioManager
+-keep class org.electricwisdom.** { *; }
+-keep interface org.electricwisdom.** { *; }
 
 ####################
 #Signpost specifics#


### PR DESCRIPTION
These changes should prevent the abstractMethod errors when building with proguard.
