### PR TITLE
Localize (i18n) “<unknown>” placeholders for Artist, Album, Query

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -221,4 +221,6 @@
   <string name="uninstall_plugin_warning">Do you really want to uninstall this Plugin?</string>
   <string name="gmusic_info_text">Choose an account:</string>
   <string name="invalid_file">Can\'t open file.</string>
+  <string name="unknown_album">Unknown album</string>
+  <string name="unknown_artist">Unknown artist</string>
 </resources>

--- a/src/org/tomahawk/libtomahawk/collection/Album.java
+++ b/src/org/tomahawk/libtomahawk/collection/Album.java
@@ -17,6 +17,9 @@
  */
 package org.tomahawk.libtomahawk.collection;
 
+import org.tomahawk.tomahawk_android.R;
+import org.tomahawk.tomahawk_android.TomahawkApp;
+
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -72,7 +75,9 @@ public class Album extends Cacheable implements AlphaComparable, ArtistAlphaComp
      * @return the name that should be displayed
      */
     public String getPrettyName() {
-        return getName().length() > 0 ? getName() : "<unknown>";
+        return getName().isEmpty() ?
+                TomahawkApp.getContext().getResources().getString(R.string.unknown_album)
+                : getName();
     }
 
     /**

--- a/src/org/tomahawk/libtomahawk/collection/Artist.java
+++ b/src/org/tomahawk/libtomahawk/collection/Artist.java
@@ -17,6 +17,9 @@
  */
 package org.tomahawk.libtomahawk.collection;
 
+import org.tomahawk.tomahawk_android.R;
+import org.tomahawk.tomahawk_android.TomahawkApp;
+
 /**
  * This class represents an {@link Artist}.
  */
@@ -63,7 +66,9 @@ public class Artist extends Cacheable implements AlphaComparable {
      * @return the name that should be displayed
      */
     public String getPrettyName() {
-        return getName().length() > 0 ? getName() : "<unknown>";
+        return getName().isEmpty() ?
+                TomahawkApp.getContext().getResources().getString(R.string.unknown_artist)
+                : getName();
     }
 
     public Image getImage() {

--- a/src/org/tomahawk/libtomahawk/resolver/Query.java
+++ b/src/org/tomahawk/libtomahawk/resolver/Query.java
@@ -26,6 +26,8 @@ import org.tomahawk.libtomahawk.collection.Image;
 import org.tomahawk.libtomahawk.collection.Playlist;
 import org.tomahawk.libtomahawk.collection.Track;
 import org.tomahawk.libtomahawk.utils.LevensteinDistance;
+import org.tomahawk.tomahawk_android.R;
+import org.tomahawk.tomahawk_android.TomahawkApp;
 import org.tomahawk.tomahawk_android.activities.TomahawkMainActivity;
 import org.tomahawk.tomahawk_android.mediaplayers.TomahawkMediaPlayer;
 
@@ -438,7 +440,9 @@ public class Query extends Cacheable implements AlphaComparable, ArtistAlphaComp
      * @return the name that should be displayed
      */
     public String getPrettyName() {
-        return getName().length() > 0 ? getName() : "<unknown>";
+        return getName().isEmpty() ?
+                TomahawkApp.getContext().getResources().getString(R.string.unknown)
+                : getName();
     }
 
     public Artist getArtist() {


### PR DESCRIPTION
Instead of displaying ugly, US-hardcoded `<unknown>` placeholders, this displays localized “Unknown artist” and “Unknown album”.