### PR TITLE
Add BASIC logging for native http requests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,6 +152,7 @@ dependencies {
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.squareup.okhttp:okhttp:2.7.2'
     compile 'com.squareup.okhttp:okhttp-urlconnection:2.7.2'
+    compile 'com.squareup.okhttp:logging-interceptor:2.7.2'
     compile 'com.github.castorflex.smoothprogressbar:library:1.1.0'
     compile 'de.mrmaffen:vlc-android-sdk:1.9.8'
     compile 'org.apache.lucene:lucene-core:4.7.2'

--- a/app/src/main/java/org/tomahawk/libtomahawk/utils/NetworkUtils.java
+++ b/app/src/main/java/org/tomahawk/libtomahawk/utils/NetworkUtils.java
@@ -1,7 +1,6 @@
 package org.tomahawk.libtomahawk.utils;
 
 import com.squareup.okhttp.Credentials;
-import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
@@ -14,7 +13,6 @@ import org.tomahawk.tomahawk_android.TomahawkApp;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.util.Log;
 
 import java.io.IOException;
 import java.net.CookieManager;

--- a/app/src/main/java/org/tomahawk/libtomahawk/utils/NetworkUtils.java
+++ b/app/src/main/java/org/tomahawk/libtomahawk/utils/NetworkUtils.java
@@ -1,17 +1,20 @@
 package org.tomahawk.libtomahawk.utils;
 
 import com.squareup.okhttp.Credentials;
+import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.MediaType;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
+import com.squareup.okhttp.logging.HttpLoggingInterceptor;
 
 import org.tomahawk.tomahawk_android.TomahawkApp;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.util.Log;
 
 import java.io.IOException;
 import java.net.CookieManager;
@@ -61,6 +64,9 @@ public class NetworkUtils {
             Map<String, String> extraHeaders, final String username, final String password,
             String data, boolean followRedirects, CookieManager cookieManager) throws IOException {
         OkHttpClient client = new OkHttpClient();
+        HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
+        loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BASIC);
+        client.networkInterceptors().add(loggingInterceptor);
         if (cookieManager != null) {
             client.setCookieHandler(cookieManager);
         }


### PR DESCRIPTION
There is logging for all other requests, why not these.

There is also HEADERS and BODY (which actually means both headers and body). 
But having that in a release could potentially leak something sensitive.